### PR TITLE
Fix bad condition in paginationEmbed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const paginationEmbed = async (msg, pages, emojiList = ['⏪', '⏩'], timeout = 120000) => {
-	if (!msg && !msg.channel) throw new Error('Channel is inaccessible.');
+	if (!msg || !msg.channel) throw new Error('Channel is inaccessible.');
 	if (!pages) throw new Error('Pages are not given.');
 	if (emojiList.length !== 2) throw new Error('Need two emojis.');
 	let page = 0;


### PR DESCRIPTION
If `!msg` then checking `msg.channel` will cause a crash anyway (and is always false). This condition should be an OR, not AND.