### PR TITLE
Changed reaction remove to not look at the .users object of the reaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const paginationEmbed = async (msg, pages, emojiList = ['⏪', '⏩'], timeout =
 		{ time: timeout }
 	);
 	reactionCollector.on('collect', reaction => {
-		reaction.users.remove(msg.author);
+		reaction.remove(msg.author.id);
 		switch (reaction.emoji.name) {
 			case emojiList[0]:
 				page = page > 0 ? --page : pages.length - 1;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const paginationEmbed = async (msg, pages, emojiList = ['⏪', '⏩'], timeout =
 	});
 	reactionCollector.on('end', () => {
 		if (!curPage.deleted) {
-			curPage.reactions.removeAll()
+			curPage.reactions.forEach((react) => { react.remove(react.message.author.id) });
 		}
 	});
 	return curPage;


### PR DESCRIPTION
Issue: Crash when trying to remove emojis in the emoji collector.
Discord-js version: 11.6.4
Errors:
`TypeError: reaction.users.remove is not a function
    at ReactionCollector.<anonymous> (\node_modules\discord.js-pagination\index.js:14:19)`
`TypeError: curPage.reactions.removeAll is not a function
    at ReactionCollector.<anonymous> (\node_modules\discord.js-pagination\index.js:28:22)`
`
I was having an issue with the pagination crashing whenever someone reacted to a message, and when the collector ends. This is due to the helper functions being used probably have been added in later discord.js versions.
This PR fixes the issue by instead relying on a function that is part of the base class of the reacts. Only tested in v11.6.4